### PR TITLE
Allow inclusion in older projects

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 let package = Package(
     name: "Flow",
     platforms: [
-        .iOS(.v16),
-        .macOS(.v13),
+        .iOS(.v15),
+        .macOS(.v12),
         .tvOS(.v16),
         .watchOS(.v9),
     ],

--- a/Sources/Flow/Example/SwiftUIView.swift
+++ b/Sources/Flow/Example/SwiftUIView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 struct SwiftUIView: View {
     @State private var axis: Axis = .horizontal
     @State private var width: CGFloat = 400
@@ -117,6 +118,7 @@ struct SwiftUIView: View {
     }
 }
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 struct SwiftUIView_Previews: PreviewProvider {
     static var previews: some View {
         SwiftUIView()

--- a/Sources/Flow/HFlow.swift
+++ b/Sources/Flow/HFlow.swift
@@ -67,10 +67,12 @@ public struct HFlow<Content: View>: View {
     }
 }
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 extension HFlow: Animatable where Content == EmptyView {
     public typealias AnimatableData = EmptyAnimatableData
 }
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 extension HFlow: Layout where Content == EmptyView {
     /// Creates a horizontal flow with the give spacing and vertical alignment.
     ///

--- a/Sources/Flow/Internal/HFlowLayout.swift
+++ b/Sources/Flow/Internal/HFlowLayout.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 struct HFlowLayout {
     private let layout: FlowLayout
 
@@ -12,6 +13,7 @@ struct HFlowLayout {
     }
 }
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 extension HFlowLayout: Layout {
     func sizeThatFits(proposal: ProposedViewSize, subviews: LayoutSubviews, cache: inout ()) -> CGSize {
         layout.sizeThatFits(proposal: proposal, subviews: subviews, cache: &cache)

--- a/Sources/Flow/Internal/Layout.swift
+++ b/Sources/Flow/Internal/Layout.swift
@@ -1,6 +1,7 @@
 import CoreFoundation
 import SwiftUI
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 struct FlowLayout {
     let axis: Axis
     var itemSpacing: CGFloat?
@@ -136,6 +137,7 @@ struct FlowLayout {
     }
 }
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 extension FlowLayout {
     static func vertical(alignment: HorizontalAlignment,
                          itemSpacing: CGFloat?,
@@ -158,15 +160,21 @@ extension FlowLayout {
     }
 }
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 protocol Subviews: RandomAccessCollection where Element: Subview, Index == Int {}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 extension LayoutSubviews: Subviews {}
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 protocol Subview {
     var spacing: ViewSpacing { get }
     func sizeThatFits(_ proposal: ProposedViewSize) -> CGSize
     func dimensions(_ proposal: ProposedViewSize) -> Dimensions
     func place(at position: CGPoint, anchor: UnitPoint, proposal: ProposedViewSize)
 }
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 extension LayoutSubview: Subview {
     func dimensions(_ proposal: ProposedViewSize) -> Dimensions {
         dimensions(in: proposal)
@@ -179,6 +187,7 @@ protocol Dimensions {
 }
 extension ViewDimensions: Dimensions {}
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 extension FlowLayout: Layout {
     func sizeThatFits(proposal proposedSize: ProposedViewSize,
                       subviews: LayoutSubviews,

--- a/Sources/Flow/Internal/Size.swift
+++ b/Sources/Flow/Internal/Size.swift
@@ -86,6 +86,7 @@ extension CGSize: FixedOrientation2DCoordinate {
     }
 }
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 extension ProposedViewSize: FixedOrientation2DCoordinate {
     init(size: Size, axis: Axis) {
         self.init(width: size[axis], height: size[axis.perpendicular])

--- a/Sources/Flow/Internal/VFlowLayout.swift
+++ b/Sources/Flow/Internal/VFlowLayout.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 struct VFlowLayout {
     private let layout: FlowLayout
 
@@ -12,6 +13,7 @@ struct VFlowLayout {
     }
 }
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 extension VFlowLayout: Layout {
     func sizeThatFits(proposal: ProposedViewSize, subviews: LayoutSubviews, cache: inout ()) -> CGSize {
         layout.sizeThatFits(proposal: proposal, subviews: subviews, cache: &cache)

--- a/Sources/Flow/VFlow.swift
+++ b/Sources/Flow/VFlow.swift
@@ -67,10 +67,12 @@ public struct VFlow<Content: View>: View {
     }
 }
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 extension VFlow: Animatable where Content == EmptyView {
     public typealias AnimatableData = EmptyAnimatableData
 }
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 extension VFlow: Layout where Content == EmptyView {
     /// Creates an instance with the given spacing and horizontal alignment.
     ///

--- a/Tests/FlowTests/FlowTests.swift
+++ b/Tests/FlowTests/FlowTests.swift
@@ -3,6 +3,7 @@ import XCTest
 @testable import Flow
 
 final class FlowTests: XCTestCase {
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
     func test_HFlow_size_singleElement() throws {
         // Given
         let views = [
@@ -17,6 +18,7 @@ final class FlowTests: XCTestCase {
         XCTAssertEqual(size, CGSize(width: 50, height: 50))
     }
 
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
     func test_HFlow_size_multipleElements() throws {
         // Given
         let views = [
@@ -33,6 +35,7 @@ final class FlowTests: XCTestCase {
         XCTAssertEqual(size, CGSize(width: 110, height: 120))
     }
 
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
     func test_HFlow_placement_centerAlignment() throws {
         // Given
         let views = [
@@ -52,7 +55,8 @@ final class FlowTests: XCTestCase {
         XCTAssertEqual(views[1].placement, CGPoint(x: 60, y: 15))
         XCTAssertEqual(views[2].placement, CGPoint(x: 0, y: 80))
     }
-
+    
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
     func test_HFlow_placement_topAlignment() throws {
         // Given
         let views = [
@@ -76,6 +80,7 @@ final class FlowTests: XCTestCase {
     }
 }
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 private final class TestSubview: Subview {
     var spacing = ViewSpacing()
     var placement: CGPoint?
@@ -98,6 +103,7 @@ private final class TestSubview: Subview {
     }
 }
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 extension Array: Subviews where Element == TestSubview {}
 
 private struct TestDimensions: Dimensions {


### PR DESCRIPTION
I set iOS and macOS back one version as fits my needs, but could be pushed further. This lets me use Flow within a project using `@available` checks for Flow usage.