### PR TITLE
Add Single-Axis Layout Support to FlowLayout

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Flow.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Flow.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Flow"
+               BuildableName = "Flow"
+               BlueprintName = "Flow"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FlowTests"
+               BuildableName = "FlowTests"
+               BlueprintName = "FlowTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Flow"
+            BuildableName = "Flow"
+            BlueprintName = "Flow"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/Flow/HFlow.swift
+++ b/Sources/Flow/HFlow.swift
@@ -20,7 +20,7 @@ import SwiftUI
 ///
 @frozen
 public struct HFlow<Content: View>: View {
-    @usableFromInline 
+    @usableFromInline
     let layout: HFlowLayout
     @usableFromInline
     let content: Content
@@ -39,14 +39,16 @@ public struct HFlow<Content: View>: View {
     ///   - distributeItemsEvenly: Instead of prioritizing the first rows, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each row, while respecting their order.
+    ///   - maxHeightForSingleRow: Maximum height threshold for forcing single row layout.
     ///   - content: A view builder that creates the content of this flow.
-    @inlinable 
+    @inlinable
     public init(
         alignment: VerticalAlignment = .center,
         itemSpacing: CGFloat? = nil,
         rowSpacing: CGFloat? = nil,
         justified: Bool = false,
         distributeItemsEvenly: Bool = false,
+        maxHeightForSingleRow: CGFloat? = nil,
         @ViewBuilder content contentBuilder: () -> Content
     ) {
         content = contentBuilder()
@@ -55,7 +57,8 @@ public struct HFlow<Content: View>: View {
             itemSpacing: itemSpacing,
             rowSpacing: rowSpacing,
             justified: justified,
-            distributeItemsEvenly: distributeItemsEvenly
+            distributeItemsEvenly: distributeItemsEvenly,
+            maxHeightForSingleRow: maxHeightForSingleRow
         )
     }
 
@@ -71,13 +74,15 @@ public struct HFlow<Content: View>: View {
     ///   - distributeItemsEvenly: Instead of prioritizing the first rows, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each row, while respecting their order.
+    ///   - maxHeightForSingleRow: Maximum height threshold for forcing single row layout.
     ///   - content: A view builder that creates the content of this flow.
-    @inlinable 
+    @inlinable
     public init(
         alignment: VerticalAlignment = .center,
         spacing: CGFloat? = nil,
         justified: Bool = false,
         distributeItemsEvenly: Bool = false,
+        maxHeightForSingleRow: CGFloat? = nil,
         @ViewBuilder content contentBuilder: () -> Content
     ) {
         self.init(
@@ -86,6 +91,7 @@ public struct HFlow<Content: View>: View {
             rowSpacing: spacing,
             justified: justified,
             distributeItemsEvenly: distributeItemsEvenly,
+            maxHeightForSingleRow: maxHeightForSingleRow,
             content: contentBuilder
         )
     }
@@ -102,6 +108,7 @@ public struct HFlow<Content: View>: View {
     ///   - distributeItemsEvenly: Instead of prioritizing the first rows, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each row, while respecting their order.
+    ///   - maxHeightForSingleRow: Maximum height threshold for forcing single row layout.
     ///   - content: A view builder that creates the content of this flow.
     @inlinable
     public init(
@@ -111,6 +118,7 @@ public struct HFlow<Content: View>: View {
         verticalSpacing: CGFloat? = nil,
         justified: Bool = false,
         distributeItemsEvenly: Bool = false,
+        maxHeightForSingleRow: CGFloat? = nil,
         @ViewBuilder content contentBuilder: () -> Content
     ) {
         content = contentBuilder()
@@ -120,14 +128,15 @@ public struct HFlow<Content: View>: View {
             horizontalSpacing: horizontalSpacing,
             verticalSpacing: verticalSpacing,
             justified: justified,
-            distributeItemsEvenly: distributeItemsEvenly
+            distributeItemsEvenly: distributeItemsEvenly,
+            maxHeightForSingleRow: maxHeightForSingleRow
         )
     }
 
     @usableFromInline
     @Environment(\.flexibility) var flexibility
 
-    @inlinable 
+    @inlinable
     public var body: some View {
         layout {
             content
@@ -155,20 +164,23 @@ extension HFlow: Layout, Sendable where Content == EmptyView {
     ///   - distributeItemsEvenly: Instead of prioritizing the first rows, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each row, while respecting their order.
-    @inlinable 
+    ///   - maxHeightForSingleRow: Maximum height threshold for forcing single row layout.
+    @inlinable
     public init(
         alignment: VerticalAlignment = .center,
         itemSpacing: CGFloat? = nil,
         rowSpacing: CGFloat? = nil,
         justified: Bool = false,
-        distributeItemsEvenly: Bool = false
+        distributeItemsEvenly: Bool = false,
+        maxHeightForSingleRow: CGFloat? = nil
     ) {
         self.init(
             alignment: alignment,
             itemSpacing: itemSpacing,
             rowSpacing: rowSpacing,
             justified: justified,
-            distributeItemsEvenly: distributeItemsEvenly
+            distributeItemsEvenly: distributeItemsEvenly,
+            maxHeightForSingleRow: maxHeightForSingleRow
         ) {
             EmptyView()
         }
@@ -186,18 +198,21 @@ extension HFlow: Layout, Sendable where Content == EmptyView {
     ///   - distributeItemsEvenly: Instead of prioritizing the first rows, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each row, while respecting their order.
-    @inlinable 
+    ///   - maxHeightForSingleRow: Maximum height threshold for forcing single row layout.
+    @inlinable
     public init(
         alignment: VerticalAlignment = .center,
         spacing: CGFloat? = nil,
         justified: Bool = false,
-        distributeItemsEvenly: Bool = false
+        distributeItemsEvenly: Bool = false,
+        maxHeightForSingleRow: CGFloat? = nil
     ) {
         self.init(
             alignment: alignment,
             spacing: spacing,
             justified: justified,
-            distributeItemsEvenly: distributeItemsEvenly
+            distributeItemsEvenly: distributeItemsEvenly,
+            maxHeightForSingleRow: maxHeightForSingleRow
         ) {
             EmptyView()
         }
@@ -215,6 +230,7 @@ extension HFlow: Layout, Sendable where Content == EmptyView {
     ///   - distributeItemsEvenly: Instead of prioritizing the first rows, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each row, while respecting their order.
+    ///   - maxHeightForSingleRow: Maximum height threshold for forcing single row layout.
     @inlinable
     public init(
         horizontalAlignment: HorizontalAlignment,
@@ -222,7 +238,8 @@ extension HFlow: Layout, Sendable where Content == EmptyView {
         horizontalSpacing: CGFloat? = nil,
         verticalSpacing: CGFloat? = nil,
         justified: Bool = false,
-        distributeItemsEvenly: Bool = false
+        distributeItemsEvenly: Bool = false,
+        maxHeightForSingleRow: CGFloat? = nil
     ) {
         self.init(
             horizontalAlignment: horizontalAlignment,
@@ -230,13 +247,14 @@ extension HFlow: Layout, Sendable where Content == EmptyView {
             horizontalSpacing: horizontalSpacing,
             verticalSpacing: verticalSpacing,
             justified: justified,
-            distributeItemsEvenly: distributeItemsEvenly
+            distributeItemsEvenly: distributeItemsEvenly,
+            maxHeightForSingleRow: maxHeightForSingleRow
         ) {
             EmptyView()
         }
     }
 
-    @inlinable 
+    @inlinable
     nonisolated public func sizeThatFits(
         proposal: ProposedViewSize,
         subviews: LayoutSubviews,
@@ -249,7 +267,7 @@ extension HFlow: Layout, Sendable where Content == EmptyView {
         )
     }
 
-    @inlinable 
+    @inlinable
     nonisolated public func placeSubviews(
         in bounds: CGRect,
         proposal: ProposedViewSize,
@@ -269,7 +287,7 @@ extension HFlow: Layout, Sendable where Content == EmptyView {
         FlowLayoutCache(subviews, axis: .horizontal)
     }
 
-    @inlinable 
+    @inlinable
     nonisolated public static var layoutProperties: LayoutProperties {
         HFlowLayout.layoutProperties
     }

--- a/Sources/Flow/HFlowLayout.swift
+++ b/Sources/Flow/HFlowLayout.swift
@@ -18,13 +18,15 @@ public struct HFlowLayout: Sendable {
     ///   - distributeItemsEvenly: Instead of prioritizing the first rows, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each row, while respecting their order.
+    ///   - maxHeightForSingleRow: Maximum height threshold for forcing single row layout.
     @inlinable
     public init(
         alignment: VerticalAlignment = .center,
         itemSpacing: CGFloat? = nil,
         rowSpacing: CGFloat? = nil,
         justified: Bool = false,
-        distributeItemsEvenly: Bool = false
+        distributeItemsEvenly: Bool = false,
+        maxHeightForSingleRow: CGFloat? = nil
     ) {
         self.init(
             horizontalAlignment: .leading,
@@ -32,7 +34,8 @@ public struct HFlowLayout: Sendable {
             horizontalSpacing: itemSpacing,
             verticalSpacing: rowSpacing,
             justified: justified,
-            distributeItemsEvenly: distributeItemsEvenly
+            distributeItemsEvenly: distributeItemsEvenly,
+            maxHeightForSingleRow: maxHeightForSingleRow
         )
     }
 
@@ -48,6 +51,7 @@ public struct HFlowLayout: Sendable {
     ///   - distributeItemsEvenly: Instead of prioritizing the first rows, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each row, while respecting their order.
+    ///   - maxHeightForSingleRow: Maximum height threshold for forcing single row layout.
     @inlinable
     public init(
         horizontalAlignment: HorizontalAlignment,
@@ -55,7 +59,8 @@ public struct HFlowLayout: Sendable {
         horizontalSpacing: CGFloat? = nil,
         verticalSpacing: CGFloat? = nil,
         justified: Bool = false,
-        distributeItemsEvenly: Bool = false
+        distributeItemsEvenly: Bool = false,
+        maxHeightForSingleRow: CGFloat? = nil
     ) {
         layout = .horizontal(
             horizontalAlignment: horizontalAlignment,
@@ -63,7 +68,8 @@ public struct HFlowLayout: Sendable {
             horizontalSpacing: horizontalSpacing,
             verticalSpacing: verticalSpacing,
             justified: justified,
-            distributeItemsEvenly: distributeItemsEvenly
+            distributeItemsEvenly: distributeItemsEvenly,
+            singleAxisThreshold: maxHeightForSingleRow
         )
     }
 }

--- a/Sources/Flow/Internal/Layout.swift
+++ b/Sources/Flow/Internal/Layout.swift
@@ -108,32 +108,25 @@ struct FlowLayout: Sendable {
                     adjust(&target, for: item, on: .horizontal, reversed: reversedBreadth) { target in
                         if isSingleAxisLayout {
                             let remainingWidth = (reversedBreadth ? bounds.minimumValue(on: axis) : bounds.maximumValue(on: axis)) - target.breadth
-                            let constrainedBreadth = min(item.size.breadth, remainingWidth)
-                            
-                            var position = target
-                            
-                            // ✅ Line depth'i hesapla (normal flow'daki gibi)
-                            let lineDepth = line.size.depth
-                            let itemDepth = item.size.depth
-                            
-                            // ✅ Alignment hesapla (alignAndPlace'teki kod)
-                            if itemDepth > 0 {
-                                let size = Size(breadth: constrainedBreadth, depth: lineDepth)
-                                let proposedSize = ProposedViewSize(size: size, axis: axis)
-                                let dimensions = item.item.subview.dimensions(proposedSize)
-                                let alignedPosition = alignmentOnDepth(dimensions)
-                                position.depth += (alignedPosition / itemDepth) * (lineDepth - itemDepth)
-                                if position.depth.isNaN {
-                                    position.depth = .infinity
+                                let constrainedBreadth = min(item.size.breadth, remainingWidth)
+                                
+                                var position = target
+                                let constrainedSize = Size(breadth: constrainedBreadth, depth: item.size.depth)
+                                let proposedSize = ProposedViewSize(size: constrainedSize, axis: axis)
+                                
+                                let lineDepth = line.size.depth
+                                let itemDepth = item.size.depth
+                                if itemDepth > 0 {
+                                    let dimensions = item.item.subview.dimensions(proposedSize)
+                                    let alignedPosition = alignmentOnDepth(dimensions)
+                                    position.depth += (alignedPosition / itemDepth) * (lineDepth - itemDepth)
+                                    if position.depth.isNaN {
+                                        position.depth = .infinity
+                                    }
                                 }
-                            }
-                            
-                            // ✅ Final placement
-                            let constrainedSize = Size(breadth: constrainedBreadth, depth: item.size.depth)
-                            let finalProposedSize = ProposedViewSize(size: constrainedSize, axis: axis)
-                            let point = CGPoint(size: position, axis: axis)
-                            
-                            item.item.subview.place(at: point, anchor: .topLeading, proposal: finalProposedSize)
+                                
+                                let point = CGPoint(size: position, axis: axis)
+                                item.item.subview.place(at: point, anchor: .topLeading, proposal: proposedSize)
                         } else {
                             alignAndPlace(item, in: line, at: target)
                         }

--- a/Sources/Flow/Internal/Layout.swift
+++ b/Sources/Flow/Internal/Layout.swift
@@ -108,14 +108,25 @@ struct FlowLayout: Sendable {
                     adjust(&target, for: item, on: .horizontal, reversed: reversedBreadth) { target in
                         if isSingleAxisLayout {
                             let remainingWidth = (reversedBreadth ? bounds.minimumValue(on: axis) : bounds.maximumValue(on: axis)) - target.breadth
-                            let constrainedBreadth = min(item.size.breadth, remainingWidth)
-                            
-                            var position = target
-                            let constrainedSize = Size(breadth: constrainedBreadth, depth: item.size.depth)
-                            let proposedSize = ProposedViewSize(size: constrainedSize, axis: axis)
-                            let point = CGPoint(size: position, axis: axis)
-                            
-                            item.item.subview.place(at: point, anchor: .topLeading, proposal: proposedSize)
+                                let constrainedBreadth = min(item.size.breadth, remainingWidth)
+                                
+                                var position = target
+                                let constrainedSize = Size(breadth: constrainedBreadth, depth: item.size.depth)
+                                let proposedSize = ProposedViewSize(size: constrainedSize, axis: axis)
+                                
+                                let lineDepth = line.size.depth
+                                let itemDepth = item.size.depth
+                                if itemDepth > 0 {
+                                    let dimensions = item.item.subview.dimensions(proposedSize)
+                                    let alignedPosition = alignmentOnDepth(dimensions)
+                                    position.depth += (alignedPosition / itemDepth) * (lineDepth - itemDepth)
+                                    if position.depth.isNaN {
+                                        position.depth = .infinity
+                                    }
+                                }
+                                
+                                let point = CGPoint(size: position, axis: axis)
+                                item.item.subview.place(at: point, anchor: .topLeading, proposal: proposedSize)
                         } else {
                             alignAndPlace(item, in: line, at: target)
                         }

--- a/Sources/Flow/Internal/Layout.swift
+++ b/Sources/Flow/Internal/Layout.swift
@@ -156,18 +156,15 @@ struct FlowLayout: Sendable {
         let proposedSize: ProposedViewSize
         
         if isSingleAxisLayout {
-            // Single-axis layout: constrain breadth to available space
             let remainingWidth = bounds.maximumValue(on: axis) - target.breadth
             let constrainedBreadth = min(item.size.breadth, remainingWidth)
             let size = Size(breadth: constrainedBreadth, depth: itemDepth)
             proposedSize = ProposedViewSize(size: size, axis: axis)
         } else {
-            // Normal flow layout: use full line depth
             let size = Size(breadth: item.size.breadth, depth: lineDepth)
             proposedSize = ProposedViewSize(size: size, axis: axis)
         }
         
-        // Apply alignment calculation for both modes
         if itemDepth > 0 {
             let dimensions = item.item.subview.dimensions(proposedSize)
             let alignedPosition = alignmentOnDepth(dimensions)

--- a/Sources/Flow/Internal/Layout.swift
+++ b/Sources/Flow/Internal/Layout.swift
@@ -245,14 +245,20 @@ struct FlowLayout: Sendable {
                 : 0
             )
             
-            let idealProposal = ProposedViewSize(
-                size: Size(breadth: subviewCache.ideal.breadth, depth: .infinity),
+            let availableWidth = proposedSize.value(on: axis)
+            let totalSpacing = CGFloat(subviews.count - 1) * spacing
+            let maxItemWidth = max(0, (availableWidth - totalSpacing) / CGFloat(subviews.count))
+            
+            let constrainedWidth = min(subviewCache.ideal.breadth, maxItemWidth)
+            
+            let constrainedProposal = ProposedViewSize(
+                size: Size(breadth: constrainedWidth, depth: .infinity),
                 axis: axis
             )
             
             return Line.Element(
                 item: (subview: subview, cache: subviewCache),
-                size: subview.sizeThatFits(idealProposal).size(on: axis),
+                size: subview.sizeThatFits(constrainedProposal).size(on: axis),
                 leadingSpace: offset == 0 ? 0 : spacing
             )
         }
@@ -261,6 +267,8 @@ struct FlowLayout: Sendable {
             .map(\.size)
             .reduce(.zero, breadth: +, depth: max)
         size.breadth += items.sum(of: \.leadingSpace)
+        
+        size.breadth = min(size.breadth, proposedSize.value(on: axis))
         
         return [Lines.Element(
             item: items,

--- a/Sources/Flow/Internal/Layout.swift
+++ b/Sources/Flow/Internal/Layout.swift
@@ -245,16 +245,14 @@ struct FlowLayout: Sendable {
                 : 0
             )
             
-            let availableDepth = proposedSize.value(on: axis) - CGFloat(subviews.count - 1) * (spacing)
-            let maxItemDepth = availableDepth / CGFloat(subviews.count)
-            let constrainedProposal = ProposedViewSize(
-                size: Size(breadth: maxItemDepth, depth: .infinity),
+            let idealProposal = ProposedViewSize(
+                size: Size(breadth: subviewCache.ideal.breadth, depth: .infinity),
                 axis: axis
             )
             
             return Line.Element(
                 item: (subview: subview, cache: subviewCache),
-                size: subview.sizeThatFits(constrainedProposal).size(on: axis),
+                size: subview.sizeThatFits(idealProposal).size(on: axis),
                 leadingSpace: offset == 0 ? 0 : spacing
             )
         }

--- a/Sources/Flow/Internal/Layout.swift
+++ b/Sources/Flow/Internal/Layout.swift
@@ -108,25 +108,32 @@ struct FlowLayout: Sendable {
                     adjust(&target, for: item, on: .horizontal, reversed: reversedBreadth) { target in
                         if isSingleAxisLayout {
                             let remainingWidth = (reversedBreadth ? bounds.minimumValue(on: axis) : bounds.maximumValue(on: axis)) - target.breadth
-                                let constrainedBreadth = min(item.size.breadth, remainingWidth)
-                                
-                                var position = target
-                                let constrainedSize = Size(breadth: constrainedBreadth, depth: item.size.depth)
-                                let proposedSize = ProposedViewSize(size: constrainedSize, axis: axis)
-                                
-                                let lineDepth = line.size.depth
-                                let itemDepth = item.size.depth
-                                if itemDepth > 0 {
-                                    let dimensions = item.item.subview.dimensions(proposedSize)
-                                    let alignedPosition = alignmentOnDepth(dimensions)
-                                    position.depth += (alignedPosition / itemDepth) * (lineDepth - itemDepth)
-                                    if position.depth.isNaN {
-                                        position.depth = .infinity
-                                    }
+                            let constrainedBreadth = min(item.size.breadth, remainingWidth)
+                            
+                            var position = target
+                            
+                            // ✅ Line depth'i hesapla (normal flow'daki gibi)
+                            let lineDepth = line.size.depth
+                            let itemDepth = item.size.depth
+                            
+                            // ✅ Alignment hesapla (alignAndPlace'teki kod)
+                            if itemDepth > 0 {
+                                let size = Size(breadth: constrainedBreadth, depth: lineDepth)
+                                let proposedSize = ProposedViewSize(size: size, axis: axis)
+                                let dimensions = item.item.subview.dimensions(proposedSize)
+                                let alignedPosition = alignmentOnDepth(dimensions)
+                                position.depth += (alignedPosition / itemDepth) * (lineDepth - itemDepth)
+                                if position.depth.isNaN {
+                                    position.depth = .infinity
                                 }
-                                
-                                let point = CGPoint(size: position, axis: axis)
-                                item.item.subview.place(at: point, anchor: .topLeading, proposal: proposedSize)
+                            }
+                            
+                            // ✅ Final placement
+                            let constrainedSize = Size(breadth: constrainedBreadth, depth: item.size.depth)
+                            let finalProposedSize = ProposedViewSize(size: constrainedSize, axis: axis)
+                            let point = CGPoint(size: position, axis: axis)
+                            
+                            item.item.subview.place(at: point, anchor: .topLeading, proposal: finalProposedSize)
                         } else {
                             alignAndPlace(item, in: line, at: target)
                         }

--- a/Sources/Flow/VFlow.swift
+++ b/Sources/Flow/VFlow.swift
@@ -39,6 +39,7 @@ public struct VFlow<Content: View>: View {
     ///   - distributeItemsEvenly: Instead of prioritizing the first columns, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each column, while respecting their order.
+    ///   - maxWidthForSingleColumn: Maximum width threshold for forcing single column layout.
     ///   - content: A view builder that creates the content of this flow.
     @inlinable
     public init(
@@ -47,6 +48,7 @@ public struct VFlow<Content: View>: View {
         columnSpacing: CGFloat? = nil,
         justified: Bool = false,
         distributeItemsEvenly: Bool = false,
+        maxWidthForSingleColumn: CGFloat? = nil,
         @ViewBuilder content contentBuilder: () -> Content
     ) {
         content = contentBuilder()
@@ -55,7 +57,8 @@ public struct VFlow<Content: View>: View {
             itemSpacing: itemSpacing,
             columnSpacing: columnSpacing,
             justified: justified,
-            distributeItemsEvenly: distributeItemsEvenly
+            distributeItemsEvenly: distributeItemsEvenly,
+            maxWidthForSingleColumn: maxWidthForSingleColumn
         )
     }
 
@@ -71,6 +74,7 @@ public struct VFlow<Content: View>: View {
     ///   - distributeItemsEvenly: Instead of prioritizing the first columns, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each column, while respecting their order.
+    ///   - maxWidthForSingleColumn: Maximum width threshold for forcing single column layout.
     ///   - content: A view builder that creates the content of this flow.
     @inlinable
     public init(
@@ -78,6 +82,7 @@ public struct VFlow<Content: View>: View {
         spacing: CGFloat? = nil,
         justified: Bool = false,
         distributeItemsEvenly: Bool = false,
+        maxWidthForSingleColumn: CGFloat? = nil,
         @ViewBuilder content contentBuilder: () -> Content
     ) {
         self.init(
@@ -86,6 +91,7 @@ public struct VFlow<Content: View>: View {
             columnSpacing: spacing,
             justified: justified,
             distributeItemsEvenly: distributeItemsEvenly,
+            maxWidthForSingleColumn: maxWidthForSingleColumn,
             content: contentBuilder
         )
     }
@@ -102,6 +108,7 @@ public struct VFlow<Content: View>: View {
     ///   - distributeItemsEvenly: Instead of prioritizing the first columns, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each column, while respecting their order.
+    ///   - maxWidthForSingleColumn: Maximum width threshold for forcing single column layout.
     ///   - content: A view builder that creates the content of this flow.
     @inlinable
     public init(
@@ -111,6 +118,7 @@ public struct VFlow<Content: View>: View {
         verticalSpacing: CGFloat? = nil,
         justified: Bool = false,
         distributeItemsEvenly: Bool = false,
+        maxWidthForSingleColumn: CGFloat? = nil,
         @ViewBuilder content contentBuilder: () -> Content
     ) {
         content = contentBuilder()
@@ -120,7 +128,8 @@ public struct VFlow<Content: View>: View {
             horizontalSpacing: horizontalSpacing,
             verticalSpacing: verticalSpacing,
             justified: justified,
-            distributeItemsEvenly: distributeItemsEvenly
+            distributeItemsEvenly: distributeItemsEvenly,
+            maxWidthForSingleColumn: maxWidthForSingleColumn
         )
     }
 
@@ -154,20 +163,23 @@ extension VFlow: Layout, Sendable where Content == EmptyView {
     ///   - distributeItemsEvenly: Instead of prioritizing the first columns, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each column, while respecting their order.
+    ///   - maxWidthForSingleColumn: Maximum width threshold for forcing single column layout.
     @inlinable
     public init(
         alignment: HorizontalAlignment = .center,
         itemSpacing: CGFloat? = nil,
         columnSpacing: CGFloat? = nil,
         justified: Bool = false,
-        distributeItemsEvenly: Bool = false
+        distributeItemsEvenly: Bool = false,
+        maxWidthForSingleColumn: CGFloat? = nil
     ) {
         self.init(
             alignment: alignment,
             itemSpacing: itemSpacing,
             columnSpacing: columnSpacing,
             justified: justified,
-            distributeItemsEvenly: distributeItemsEvenly
+            distributeItemsEvenly: distributeItemsEvenly,
+            maxWidthForSingleColumn: maxWidthForSingleColumn
         ) {
             EmptyView()
         }
@@ -185,18 +197,21 @@ extension VFlow: Layout, Sendable where Content == EmptyView {
     ///   - distributeItemsEvenly: Instead of prioritizing the first columns, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each column, while respecting their order.
+    ///   - maxWidthForSingleColumn: Maximum width threshold for forcing single column layout.
     @inlinable
     public init(
         alignment: HorizontalAlignment = .center,
         spacing: CGFloat? = nil,
         justified: Bool = false,
-        distributeItemsEvenly: Bool = false
+        distributeItemsEvenly: Bool = false,
+        maxWidthForSingleColumn: CGFloat? = nil
     ) {
         self.init(
             alignment: alignment,
             spacing: spacing,
             justified: justified,
-            distributeItemsEvenly: distributeItemsEvenly
+            distributeItemsEvenly: distributeItemsEvenly,
+            maxWidthForSingleColumn: maxWidthForSingleColumn
         ) {
             EmptyView()
         }
@@ -210,10 +225,11 @@ extension VFlow: Layout, Sendable where Content == EmptyView {
     ///   - verticalAlignment: The guide for aligning the subviews vertically.
     ///   - verticalSpacing: The distance between subviews on the vertical axis.
     ///   - justified: Whether the layout should fill the remaining
-    ///     available space in each column by stretching either items or spaces.
+    ///     available space in each column by stretching spaces.
     ///   - distributeItemsEvenly: Instead of prioritizing the first columns, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each column, while respecting their order.
+    ///   - maxWidthForSingleColumn: Maximum width threshold for forcing single column layout.
     @inlinable
     public init(
         horizontalAlignment: HorizontalAlignment,
@@ -221,7 +237,8 @@ extension VFlow: Layout, Sendable where Content == EmptyView {
         horizontalSpacing: CGFloat? = nil,
         verticalSpacing: CGFloat? = nil,
         justified: Bool = false,
-        distributeItemsEvenly: Bool = false
+        distributeItemsEvenly: Bool = false,
+        maxWidthForSingleColumn: CGFloat? = nil
     ) {
         self.init(
             horizontalAlignment: horizontalAlignment,
@@ -229,7 +246,8 @@ extension VFlow: Layout, Sendable where Content == EmptyView {
             horizontalSpacing: horizontalSpacing,
             verticalSpacing: verticalSpacing,
             justified: justified,
-            distributeItemsEvenly: distributeItemsEvenly
+            distributeItemsEvenly: distributeItemsEvenly,
+            maxWidthForSingleColumn: maxWidthForSingleColumn
         ) {
             EmptyView()
         }

--- a/Sources/Flow/VFlowLayout.swift
+++ b/Sources/Flow/VFlowLayout.swift
@@ -20,13 +20,15 @@ public struct VFlowLayout {
     ///   - distributeItemsEvenly: Instead of prioritizing the first columns, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each column, while respecting their order.
+    ///   - maxWidthForSingleColumn: Maximum width threshold for forcing single column layout.
     @inlinable
     public init(
         alignment: HorizontalAlignment = .center,
         itemSpacing: CGFloat? = nil,
         columnSpacing: CGFloat? = nil,
         justified: Bool = false,
-        distributeItemsEvenly: Bool = false
+        distributeItemsEvenly: Bool = false,
+        maxWidthForSingleColumn: CGFloat? = nil
     ) {
         self.init(
             horizontalAlignment: alignment,
@@ -34,7 +36,8 @@ public struct VFlowLayout {
             horizontalSpacing: columnSpacing,
             verticalSpacing: itemSpacing,
             justified: justified,
-            distributeItemsEvenly: distributeItemsEvenly
+            distributeItemsEvenly: distributeItemsEvenly,
+            maxWidthForSingleColumn: maxWidthForSingleColumn
         )
     }
 
@@ -50,7 +53,7 @@ public struct VFlowLayout {
     ///   - distributeItemsEvenly: Instead of prioritizing the first columns, this
     ///     mode tries to distribute items more evenly by minimizing the empty
     ///     spaces left in each column, while respecting their order.
-    ///   - content: A view builder that creates the content of this flow.
+    ///   - maxWidthForSingleColumn: Maximum width threshold for forcing single column layout.
     @inlinable
     public init(
         horizontalAlignment: HorizontalAlignment,
@@ -58,7 +61,8 @@ public struct VFlowLayout {
         horizontalSpacing: CGFloat? = nil,
         verticalSpacing: CGFloat? = nil,
         justified: Bool = false,
-        distributeItemsEvenly: Bool = false
+        distributeItemsEvenly: Bool = false,
+        maxWidthForSingleColumn: CGFloat? = nil
     ) {
         layout = .vertical(
             horizontalAlignment: horizontalAlignment,
@@ -66,7 +70,8 @@ public struct VFlowLayout {
             horizontalSpacing: horizontalSpacing,
             verticalSpacing: verticalSpacing,
             justified: justified,
-            distributeItemsEvenly: distributeItemsEvenly
+            distributeItemsEvenly: distributeItemsEvenly,
+            singleAxisThreshold: maxWidthForSingleColumn
         )
     }
 }


### PR DESCRIPTION
### Overview

This PR introduces a new `singleAxisThreshold` parameter to FlowLayout that enables single-axis layout behavior when items are below a specified depth/height threshold. This feature allows **FlowLayout** to behave like an `HStack` or `VStack` when content is small enough, while maintaining normal flow behavior for larger content.

### Background & Motivation
I encountered a specific issue while working on an app that transitions between list and grid layouts using `UICollectionView` with `UIHostingConfiguration`.

**My Problem:** I was using `HFlow` to create smooth animations between list mode (single row) and grid mode (multi-row). However, in list mode, when text was too long to fit on one line, `HFlow` would wrap it to the next line (which is its intended behavior), but this broke my desired single-row layout aesthetic.

**My Solution:** I needed a way to make `HFlow` behave like an `HStack` when items are small enough (staying in one line), but still flow normally when items are larger.

### My Use Case
- Building smooth list ↔ grid transitions in `UICollectionView`
- List mode: Want single-row layout with text truncation (not wrapping)
- Grid mode: Want normal flow behavior with text wrapping
- Need consistent behavior for smooth animations

While this solves my specific problem, I thought it might be useful for others dealing with similar layout challenges.

### Key Changes
1. **Layout Core:** Added `singleAxisThreshold` property
2. **Layout Calculation:** New `createSingleAxisLayout()` method for single-axis behavior
3. **Placement Logic:** Added single-axis layout handling in `placeSubviews()` for the new threshold feature

### Technical Details
- **No Breaking Changes:** Existing flow logic remains completely untouched
- **Conditional Behavior:** New single-axis logic only activates when `singleAxisThreshold` property is not `nil`
- **Fully Backward Compatible:** All existing code continues to work exactly as before
- **Clean Implementation:** Single-axis layout detection and constraint handling added without modifying core flow behavior

### Testing Status
**⚠️ Note**: I have thoroughly tested the `HFlow` implementation with `maxHeightForSingleRow`, but `VFlow` with `maxWidthForSingleColumn` is implemented based on the same logic and may need additional testing. Both parameters have been added for consistency.


### Usage Example

```swift
struct ContentView: View {
    @State var maxHeight: CGFloat? = nil
    
    var body: some View {
        VStack {
            HFlow(maxHeightForSingleRow: maxHeight) {
                RoundedRectangle(cornerRadius: 10)
                    .fill(.red)
                    .frame(width: 50, height: 50)
                
                VStack(alignment: .leading) {
                    Text("Lorem ipsum dolor sit amet, consectetur.")
                    Text("Nulla convallis.")
                }
                .lineLimit(1)
                .frame(maxWidth: .infinity, alignment: .leading)
                .frame(height: 50)
                .background(.blue, in: .rect(cornerRadius: 10))
            }
            .frame(width: 300)
            
            Spacer()
            
            Button("Switch") {
                if maxHeight == nil {
                    maxHeight = 50
                } else {
                    maxHeight = nil
                }
            }
            .buttonStyle(.borderedProminent)
        }
        .padding(.vertical, 200)
        .animation(.default, value: maxHeight)
    }
}
```


https://github.com/user-attachments/assets/18993888-210f-4fe7-a331-0d35568f5705





### In My Project
**BEFORE:**
![IMG_85C53AD9DF44-1](https://github.com/user-attachments/assets/d24477e1-04c9-4abe-8fdf-67871441acbe)


**AFTER:**

https://github.com/user-attachments/assets/64aff784-8fef-4ce8-bb9e-b68799fe92e7




