### PR TITLE
Fix cross-axis baseline alignment in flow layout

### DIFF
--- a/Sources/Flow/Internal/Layout.swift
+++ b/Sources/Flow/Internal/Layout.swift
@@ -41,6 +41,10 @@ struct FlowLayout: Sendable {
         var item: T
         var size: Size
         var leadingSpace: CGFloat = 0
+        /// Offset (from the leading depth edge) of the cross-axis alignment guide.
+        /// For an item this is e.g. its text baseline; for a line it is the line's
+        /// common guide (the max guide of its items, i.e. the ascent).
+        var depthAlignmentGuide: CGFloat = 0
     }
 
     private typealias Item = (subview: any Subview, cache: FlowLayoutCache.SubviewCache)
@@ -121,15 +125,11 @@ struct FlowLayout: Sendable {
         let lineDepth = line.size.depth
         let size = Size(breadth: item.size.breadth, depth: lineDepth)
         let proposedSize = ProposedViewSize(size: size, axis: axis)
-        let itemDepth = item.size.depth
-        if itemDepth > 0 {
-            let dimensions = item.item.subview.dimensions(proposedSize)
-            let alignedPosition = alignmentOnDepth(dimensions)
-            // Skip a non-finite offset (e.g. unbounded item/line depth).
-            let offset = (alignedPosition / itemDepth) * (lineDepth - itemDepth)
-            if offset.isFinite {
-                position.depth += offset
-            }
+        // Align the item's guide (e.g. its baseline) onto the line's common guide.
+        let offset = line.depthAlignmentGuide - item.depthAlignmentGuide
+        // Skip a non-finite offset (e.g. unbounded item/line depth).
+        if offset.isFinite {
+            position.depth += offset
         }
         // Never hand a non-finite coordinate to CoreGraphics.
         let point = CGPoint(size: position, axis: axis).finite(or: 0)
@@ -179,24 +179,33 @@ struct FlowLayout: Sendable {
         )
 
         var lines: Lines = wrapped.map { line in
-            let items = line.map { item in
-                Line.Element(
-                    item: (subview: subviews[item.index], cache: cache.subviewsCache[item.index]),
-                    size: subviews[item.index]
-                        .sizeThatFits(ProposedViewSize(size: Size(breadth: item.size, depth: .infinity), axis: axis))
-                        .size(on: axis),
-                    leadingSpace: item.leadingSpace
+            let items = line.map { item -> Line.Element in
+                let subview = subviews[item.index]
+                let proposal = ProposedViewSize(size: Size(breadth: item.size, depth: .infinity), axis: axis)
+                let dimensions = subview.dimensions(proposal)
+                return Line.Element(
+                    item: (subview: subview, cache: cache.subviewsCache[item.index]),
+                    size: dimensions.size(on: axis),
+                    leadingSpace: item.leadingSpace,
+                    depthAlignmentGuide: alignmentOnDepth(dimensions)
                 )
             }
+            // Depth is baseline-aware: enough room for the deepest guide (ascent)
+            // plus the deepest extent below it (descent). For top/center/bottom
+            // guides this reduces to the tallest item.
+            let ascent = items.map(\.depthAlignmentGuide).max() ?? 0
+            let descent = items.map { $0.size.depth - $0.depthAlignmentGuide }.max() ?? 0
             var size =
                 items
                 .map(\.size)
                 .reduce(.zero, breadth: +, depth: max)
+            size.depth = ascent + descent
             size.breadth += items.sum(of: \.leadingSpace)
             return Lines.Element(
                 item: items,
                 size: size,
-                leadingSpace: 0
+                leadingSpace: 0,
+                depthAlignmentGuide: ascent
             )
         }
 

--- a/Tests/FlowTests/Integration/LayoutEngineTests.swift
+++ b/Tests/FlowTests/Integration/LayoutEngineTests.swift
@@ -294,6 +294,51 @@ struct LayoutEngineTests {
         }
     }
 
+    // MARK: - Baseline Alignment
+
+    @Test func HFlow_firstTextBaseline_alignsBaselines() {
+        // Items of different heights with baselines at absolute (non-proportional)
+        // offsets must be placed so their first baselines coincide, like HStack.
+        let sut: FlowLayout = .horizontal(verticalAlignment: .firstTextBaseline, horizontalSpacing: 0, verticalSpacing: 0)
+        let small = TestSubview(size: 3 × 4)
+        small.firstBaseline = 3
+        let large = TestSubview(size: 3 × 10)
+        large.firstBaseline = 8
+        let result = sut.layout([small, large], in: 100 × 100)
+        // ascent = max(3, 8) = 8; small.y = 8 - 3 = 5, large.y = 8 - 8 = 0.
+        #expect(result.subviews[0].placement?.position.y == 5, "small should drop so its baseline meets the line baseline")
+        #expect(result.subviews[1].placement?.position.y == 0, "large defines the line baseline and stays at the top")
+        // Baselines coincide at y = 8.
+        let smallBaseline = (result.subviews[0].placement?.position.y ?? 0) + 3
+        let largeBaseline = (result.subviews[1].placement?.position.y ?? 0) + 8
+        #expect(smallBaseline == largeBaseline)
+    }
+
+    @Test func HFlow_firstTextBaseline_reservesDescentBelowBaseline() {
+        // The line must be tall enough for the deepest descent below the common
+        // baseline, not merely the tallest item.
+        let sut: FlowLayout = .horizontal(verticalAlignment: .firstTextBaseline, horizontalSpacing: 0, verticalSpacing: 0)
+        let a = TestSubview(size: 3 × 6)
+        a.firstBaseline = 5  // descent 1
+        let b = TestSubview(size: 3 × 6)
+        b.firstBaseline = 2  // descent 4
+        let size = sut.sizeThatFits(proposal: 100 × 100, subviews: [a, b])
+        // ascent = max(5, 2) = 5; descent = max(1, 4) = 4; height = 9.
+        #expect(size.height == 9)
+    }
+
+    @Test func HFlow_lastTextBaseline_alignsBaselines() {
+        let sut: FlowLayout = .horizontal(verticalAlignment: .lastTextBaseline, horizontalSpacing: 0, verticalSpacing: 0)
+        let small = TestSubview(size: 3 × 4)
+        small.lastBaseline = 3
+        let large = TestSubview(size: 3 × 10)
+        large.lastBaseline = 8
+        let result = sut.layout([small, large], in: 100 × 100)
+        // ascent = max(3, 8) = 8; small.y = 5, large.y = 0.
+        #expect(result.subviews[0].placement?.position.y == 5)
+        #expect(result.subviews[1].placement?.position.y == 0)
+    }
+
     // MARK: - Non-finite Arithmetic Safety
 
     @Test func HFlow_infiniteDepthItem_placesWithFiniteCoordinates() {

--- a/Tests/FlowTests/Utils/TestSubview.swift
+++ b/Tests/FlowTests/Utils/TestSubview.swift
@@ -10,6 +10,8 @@ class TestSubview: Flow.Subview, CustomStringConvertible {
     var minSize: CGSize
     var idealSize: CGSize
     var maxSize: CGSize
+    var firstBaseline: CGFloat?
+    var lastBaseline: CGFloat?
     var layoutValues: [ObjectIdentifier: Any] = [:]
 
     init(size: CGSize) {
@@ -53,7 +55,7 @@ class TestSubview: Flow.Subview, CustomStringConvertible {
                 case .infinity: maxSize
                 default: sizeThatFits(proposal)
             }
-        return TestDimensions(width: size.width, height: size.height)
+        return TestDimensions(width: size.width, height: size.height, firstBaseline: firstBaseline, lastBaseline: lastBaseline)
     }
 
     func place(at position: CGPoint, anchor: UnitPoint, proposal: ProposedViewSize) {
@@ -196,6 +198,8 @@ func labeledRender(_ layout: LayoutDescription) -> String {
 
 private struct TestDimensions: Dimensions {
     let width, height: CGFloat
+    var firstBaseline: CGFloat?
+    var lastBaseline: CGFloat?
 
     subscript(guide: HorizontalAlignment) -> CGFloat {
         switch guide {
@@ -209,6 +213,8 @@ private struct TestDimensions: Dimensions {
         switch guide {
             case .center: 0.5 * height
             case .bottom: height
+            case .firstTextBaseline: firstBaseline ?? 0
+            case .lastTextBaseline: lastBaseline ?? height
             default: 0
         }
     }


### PR DESCRIPTION
HFlow(alignment: .firstTextBaseline) did not align item baselines like HStack does. The depth alignment used a proportional formula (guide/itemDepth)*(lineDepth-itemDepth), which is only correct when the guide is a fixed fraction of the item's height (top/center/bottom). A text baseline sits at an absolute offset, so items were mis-positioned and the line height (max item depth) reserved no room below the common baseline.

Switch to the guide-based model HStack uses: per line, ascent = max guide, descent = max(itemDepth - guide), line depth = ascent + descent, and each item is placed at depth += ascent - itemGuide. This reduces exactly to the previous behavior for top/center/bottom guides. The per-item guide is now computed once during layout and stored, removing a duplicate dimensions query in alignAndPlace. Non-finite arithmetic guards are preserved.

Fixes #37
